### PR TITLE
Minor fix to DEBUG_COMPILE/EXEC build and more .gitignore things.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ TAGS
 snek-builtin.h
 snek-gram.h
 snek.pc
-*.o
+**/*.o
+**/*.pyc
+**/__pycache__

--- a/snek-code.c
+++ b/snek-code.c
@@ -235,6 +235,10 @@ snek_code_dump_instruction(snek_code_t *code, snek_offset_t ip)
 	return ip + snek_op_extra_size(op);
 }
 
+#endif
+
+#ifdef DEBUG_COMPILE
+
 static void
 snek_code_dump(snek_code_t *code)
 {


### PR DESCRIPTION
- Build failed if only DEBUG_COMPILE/EXEC was defined.
- Added __pycache__ and *.pyc to .gitignore
