### PR TITLE
Add assert statement support

### DIFF
--- a/snek-code.c
+++ b/snek-code.c
@@ -131,6 +131,8 @@ const char * const snek_op_names[] = {
 	[snek_op_assign_named] = "assign_named",
 
 	[snek_op_global] = "global",
+	[snek_op_del] = "del",
+	[snek_op_assert] = "assert",
 
 	[snek_op_branch] = "branch",
 	[snek_op_branch_true] = "branch_true",
@@ -1175,6 +1177,11 @@ snek_code_run(snek_code_t *code_in)
 					}
 				} else {
 					snek_id_del(id);
+				}
+				break;
+			case snek_op_assert:
+				if (!snek_poly_true(snek_a)) {
+					snek_error_0("AssertionError");
 				}
 				break;
 			case snek_op_branch:

--- a/snek-gram.ll
+++ b/snek-gram.ll
@@ -107,7 +107,13 @@ small-stat	: assign-expr
 		| PASS
 		| GLOBAL globals
 		| DEL del dels-p
+		| ASSERT assert
 		;
+
+assert  : expr
+			@{ snek_code_add_op(snek_op_assert); }@
+		;
+
 dels-p		: COMMA del
 		  dels-p
 		|

--- a/snek.h
+++ b/snek.h
@@ -138,6 +138,7 @@ typedef enum {
 
 	snek_op_global,
 	snek_op_del,
+	snek_op_assert,
 
 	snek_op_branch,
 	snek_op_branch_true,

--- a/test/Makefile
+++ b/test/Makefile
@@ -41,7 +41,8 @@ SUCCESS_TESTS = \
 	scoping-global.py \
 	scoping-local.py \
 	none.py \
-	args.py
+	args.py \
+	assert-success.py
 
 FAIL_TESTS = \
 	scoping-no-decl.py \
@@ -53,7 +54,8 @@ FAIL_TESTS = \
 	args-missing.py \
 	arg-dup1.py \
 	arg-dup2.py \
-	arg-unknown.py
+	arg-unknown.py \
+	assert-fail.py
 
 check:
 	@exit=0; \

--- a/test/assert-fail.py
+++ b/test/assert-fail.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Keith Packard <keithp@keithp.com>
+# Copyright © 2019 Paulo Henrique Silva <ph.silva@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,23 +11,8 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
-def, DEF
-del, DEL
-global, GLOBAL
-assert, ASSERT
-if, IF
-else, ELSE
-elif, ELIF
-for, FOR
-while, WHILE
-continue, CONTINUE
-pass, PASS
-break, BREAK
-return, RETURN
-import, IMPORT
-range, RANGE
-or, OR
-and, AND
-is, IS
-in, IN
-not, NOT
+#
+# Check assert failure
+#
+
+assert 42 == 41

--- a/test/assert-success.py
+++ b/test/assert-success.py
@@ -1,5 +1,5 @@
 #
-# Copyright © 2019 Keith Packard <keithp@keithp.com>
+# Copyright © 2019 Paulo Henrique Silva <ph.silva@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,23 +11,13 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
-def, DEF
-del, DEL
-global, GLOBAL
-assert, ASSERT
-if, IF
-else, ELSE
-elif, ELIF
-for, FOR
-while, WHILE
-continue, CONTINUE
-pass, PASS
-break, BREAK
-return, RETURN
-import, IMPORT
-range, RANGE
-or, OR
-and, AND
-is, IS
-in, IN
-not, NOT
+#
+# Check assert success
+#
+
+assert 42 == 42
+assert True
+assert 1
+assert [42]
+assert "true"
+assert "false"  # string s is True if len(s) > 0


### PR DESCRIPTION
This PR adds assert <expr> statement support to Snek.

When <expr> evaluates to False (per snek_poly_true criteria)
assert will print an AssertionError.

In the future, we could add __debug__ so we can ignore
assertions while __debug__ is false.

**note** this is mostly an experiment to learn more about snek internals... not a very useful language feature but required a bit of internal knowledge.