### PR TITLE
Add PEP 515 Underscore in Numeric Literals support

### DIFF
--- a/doc/snek.adoc
+++ b/doc/snek.adoc
@@ -385,6 +385,16 @@ understand the mathematical convention that adjacent values should be
 multiplied. The return statement is how we tell Snek that this
 function computes a value that should be given back to the caller.
 
+Numbers in Snek could be written using `_` as a separator, which is
+specially useful when writing large numbers.
+
+[source,subs="verbatim,quotes"]
+----
+> # you can write
+> c = 299_792_458
+> # and Snek will interpret as
+> c = 299792458
+----
 [#for_range]
 === Loops, Ranges and Printing Two Values
 

--- a/doc/snek.adoc
+++ b/doc/snek.adoc
@@ -385,7 +385,7 @@ understand the mathematical convention that adjacent values should be
 multiplied. The return statement is how we tell Snek that this
 function computes a value that should be given back to the caller.
 
-Numbers in Snek could be written using `_` as a separator, which is
+Numbers in Snek may be written using `_` as a separator, which is
 specially useful when writing large numbers.
 
 [source,subs="verbatim,quotes"]

--- a/doc/snek.adoc
+++ b/doc/snek.adoc
@@ -386,7 +386,7 @@ multiplied. The return statement is how we tell Snek that this
 function computes a value that should be given back to the caller.
 
 Numbers in Snek may be written using `_` as a separator, which is
-specially useful when writing large numbers.
+especially useful when writing large numbers.
 
 [source,subs="verbatim,quotes"]
 ----

--- a/snek-lex.c
+++ b/snek-lex.c
@@ -161,6 +161,7 @@ typedef enum nclass {
 	c_e,
 	c_sign,
 	c_other,
+	c_underscore
 } __attribute__((packed)) nclass_t;
 
 static nclass_t
@@ -174,6 +175,8 @@ cclass(char c)
 		return c_e;
 	if (c == '-' || c == '+')
 		return c_sign;
+	if (c == '_')
+		return c_underscore;
 	return c_other;
 }
 
@@ -181,11 +184,11 @@ static token_t
 number(char c)
 {
 	nstate_t n = n_int;
-	nclass_t t;
+	nclass_t t = c_digit;
 
 	start_token();
 	for (;;) {
-		if (!add_token(c))
+		if (t != c_underscore && !add_token(c))
 			RETURN(TOKEN_NONE);
 		c = lexchar();
 		t = cclass(c);
@@ -193,6 +196,7 @@ number(char c)
 		case n_int:
 			switch (t) {
 			case c_digit:
+			case c_underscore:
 				continue;
 			case c_dot:
 				n = n_frac;

--- a/test/Makefile
+++ b/test/Makefile
@@ -31,6 +31,7 @@ SUCCESS_TESTS = \
 	for-nested.py \
 	global.py \
 	if.py \
+	int.py \
 	math.py \
 	op.py \
 	range.py \

--- a/test/int.py
+++ b/test/int.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python3
+#
+# Copyright © 2019 Paulo Henrique Silva <ph.silva@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+
+
+def fail(which):
+    print("fail %s" % which)
+    exit(1)
+
+
+def check(a, b, which):
+    if a > b or a < b:
+        fail(which)
+
+
+check(1_2_3, 123, "1_2_3 should be equal to 123")
+check(10_000_000, 10000000, "10_000_000 should be equal to 10000000")


### PR DESCRIPTION
This PR adds basic PEP 515 support. PEP 515 allows use of '_' as numeric separator in integer, so you can write 10_000 instead of 10000, which is somewhat more readable.

https://www.python.org/dev/peps/pep-0515/