### PR TITLE
ports/duemilanove: Reduce size of has_pwm() function

### DIFF
--- a/ports/duemilanove/snek-duemilanove.c
+++ b/ports/duemilanove/snek-duemilanove.c
@@ -180,7 +180,12 @@ is_pull(uint8_t pin)
 static bool
 has_pwm(uint8_t p)
 {
-	return ((p) == 3 || (p) == 5 || (p) == 6 || (p) == 9 || (p) == 10 || (p) == 11);
+	const uint16_t pwm_pins = (1 << 3) | (1 << 5) | (1 << 6)
+				| (1 << 9) | (1 << 10) | (1 << 11);
+
+	p &= 15;
+
+	return pwm_pins & 1 << p;
 }
 
 static volatile uint8_t * const PROGMEM ocr_reg_addrs[] = {


### PR DESCRIPTION
Use a lookup table in an uint16_t to map which pins are capable of PWM.

When built with GCC AVR 5.4.0 (the only one for AVR available in compiler explorer), [this reduces the size of has_pwm() from 19 instructions to 12 instructions](https://gcc.godbolt.org/z/3WKwzx).

It's not exactly the same function, however it should work fine in the Duemilanove where you have only 14 pins capable of PWM.