### PR TITLE
Use Github Actions for CI/CD and testing

### DIFF
--- a/.github/workflows/snek.yml
+++ b/.github/workflows/snek.yml
@@ -1,0 +1,31 @@
+name: snek
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: phsilva/snek:latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - run: make
+      - run: make check
+      - name: prepare artifacts
+        run: |
+          mkdir -p artifacts
+
+          for f in $(find ports -iname '*.uf2' -or -iname '*.hex' -or -iname '*.bin' -or -iname '*.map' -or -iname '*qemu-*.elf'); do
+            cp -v "$f" artifacts
+          done
+
+          for f in $(find hosts -iname 'snek-*.exe' -or -iname 'snek-*.sh' -or -iname 'snek-*.dmg'); do
+            cp -v "$f" artifacts
+          done
+
+          cp -v doc/snek.pdf doc/snek.html doc/snek.css artifacts
+      - uses: actions/upload-artifact@v1
+        with:
+          name: snek
+          path: artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# snek toolchain
+#
+# VERSION               0.1
+
+FROM debian:unstable
+
+RUN apt-get update && apt-get install -y \
+    wget \
+    build-essential \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN wget -O - https://keithp.com/archive/archive-key | \
+    apt-key add - && echo 'deb   http://keithp.com/archive unstable/' > /etc/apt/sources.list.d/keithp.list
+
+RUN apt-get update && apt-get install -y \
+    libreadline-dev \
+    gawk \
+    lola \
+    gcc-avr \
+    avr-libc \
+    python3-serial \
+    gcc-arm-none-eabi \
+    gcc-riscv64-unknown-elf \
+    qemu-system-riscv32 \
+    qemu-system-arm \
+    picolibc-riscv64-unknown-elf \
+    picolibc-arm-none-eabi \
+    rsync \
+    librsvg2-bin \
+    asciidoctor \
+    ruby-asciidoctor-pdf \
+    coderay \
+    gcc-mingw-w64-i686 \
+    icoutils \
+    nsis \
+    icnsutils \
+    genisoimage \
+    python3-pip \
+ && python3 -m pip install pynsist \
+ && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,9 @@ snek.pc: snek.pc.in
 snek-mu.py:
 	find . -name '*.builtin' -print0 | xargs -0 python3 ./snek-builtin.py --mu -o $@
 
+docker:
+	docker build -t phsilva/snek .
+
 clean:
 	rm -f snek.pc
 	+for dir in $(SUBDIRS); do (cd $$dir && make PREFIX=$(PREFIX) DESTDIR=$(DESTDIR) $@); done


### PR DESCRIPTION
# Use new Github Actions system to implement a CI.

This workflow depends on [phsilva/snek](https://hub.docker.com/r/phsilva/snek) image on docker hub. That image proves all required dependencies built from Debian unstable necessary to build all snek ports, including qemu based (Dockerfile used included here for time being, could be moved to a new repo if needed).

The workflow saves most of the artifacts generated during build, like .bin, .hex, .uf2, .map, .elf (for qemu targets) and snek docs. We could use this coupled with Github releases to generate final release packages. Artifacts could be downloaded in the actions build, top right corner close to the logs.

![Screenshot_2019-11-21 phsilva snek](https://user-images.githubusercontent.com/1095/69313312-f6a0d680-0c0f-11ea-9060-e805c57512e3.png)
