### PR TITLE
ports/lilypad328: LilyPad Arduino 328 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ described below.
 
  * [Arduino Nano Every](https://store.arduino.cc/usa/nano-every).
 
+ * [LilyPad Arduino 328](https://www.sparkfun.com/products/13342).
+
 ## To Do list
 
  * Convert parser from LL to SLR. The hope here is to reduce the

--- a/doc/snek.adoc
+++ b/doc/snek.adoc
@@ -2402,12 +2402,13 @@ package for your machine and copy it to the snekboard file system.
 
 [%nonfacing]
 [appendix]
-= Snek on Arduino Duemilanove and Uno
+= Snek on Arduino Duemilanove, Uno and Lilypad
 
-Snek for the Duemilanove and for the Uno include the Common System, EEPROM, and GPIO
-functions. They do not include the Math functions, nor the `pulldown`
-function. Snek for the Duemilanove and for the Uno provides pre-defined variables for
-all of the GPIO pins:(((Duemilanove)))(((Uno)))(((Arduino)))
+Snek for the Duemilanove, Uno and for the Lilypad include the Common
+System, EEPROM, and GPIO functions. They do not include the Math
+functions, nor the `pulldown` function. Snek for the Duemilanove, Uno
+and for the Lilypad provides pre-defined variables for all of the GPIO
+pins:(((Duemilanove)))(((Uno)))(((Arduino)))(((Lilypad)))
 
 D0 - D13::
 Digital input and output pins. By default, when used as input pins,
@@ -2422,18 +2423,18 @@ either a pull-up or pull-down resistor to the pin so that a
 disconnected pin will read an indeterminate value. Change this using
 `pullnone` or `pullup` functions.
 
-=== Installing Optiboot on the Duemilanove
+=== Installing Optiboot on the Duemilanove and Lilypad
 
 Snek nearly fills the ATMega 328P flash, leaving space only for the
 smaller optiboot loader. This loader is not usually installed on the
-Duemilanove, so you'll need to install it by hand using a programming
-puck, such as the USBTiny device.
+Duemilanove and Lilypad, so you'll need to install it by hand using a
+programming puck, such as the USBTiny device.
 
 Use the Arduino IDE to install the Optiboot boot loader following
 instructions found on the
 link:https://github.com/Optiboot/optiboot[Optiboot web site].
 
-=== Installing Snek on the Duemilanove and Uno
+=== Installing Snek on the Duemilanove, Uno and Lilypad
 
 Once your board is ready to install snek, you can use avrdude to do
  that with Optiboot. On Linux, you can use the snek-uno-install command:

--- a/hosts/linux/Makefile
+++ b/hosts/linux/Makefile
@@ -28,7 +28,8 @@ PROGS= \
 	$(SNEK_PORTS)/duemilanove/snek-duemilanove-install.in \
 	$(SNEK_PORTS)/itsybitsy5v/snek-itsybitsy-install.in \
 	$(SNEK_PORTS)/mega/snek-mega-install.in \
-	$(SNEK_PORTS)/uno/snek-uno-install.in
+	$(SNEK_PORTS)/uno/snek-uno-install.in \
+	$(SNEK_PORTS)/lilypad328/snek-lilypad328-install.in
 
 EXAMPLES=$(SNEK_ROOT)/examples
 

--- a/ports/lilypad328/.gitignore
+++ b/ports/lilypad328/.gitignore
@@ -1,0 +1,5 @@
+snek-lilypad328-*.elf
+snek-lilypad328-*.hex
+snek-lilypad328-*.map
+snek-lilypad328-install
+snek-lilypad328-install.1

--- a/ports/lilypad328/Makefile
+++ b/ports/lilypad328/Makefile
@@ -1,0 +1,34 @@
+#
+# Copyright © 2020 Keith Packard <keithp@keithp.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+
+vpath %.in ../duemilanove
+
+BOARD=lilypad328
+CBOARD=LilyPad328
+UBOARD=LILYPAD328
+PORT=/dev/ttyACM0
+
+include ../duemilanove/Makefile
+
+SNEK_CFLAGS = $(SNEK_MOST_WARNINGS) $(SNEK_BASE_CFLAGS) -DUART_BAUD=38400
+
+CFLAGS=$(OPT) -DF_CPU=8000000UL -mmcu=atmega328p -I. -I$(SNEK_LOCAL_VPATH) -g $(SNEK_CFLAGS) -Waddr-space-convert
+
+all:: snek-$(BOARD)-install.in
+
+snek-$(BOARD)-install.in: snek-duemilanove-install.in
+	sed -e 's;@BOARD@;$(BOARD);g' \
+	-e 's;@UBOARD@;$(UBOARD);g' \
+	-e 's;@CBOARD@;$(CBOARD);g' \
+	-e 's;@PORT@;$(PORT);g' $^ > $@

--- a/ports/lilypad328/snek-lilypad328-install.in
+++ b/ports/lilypad328/snek-lilypad328-install.in
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+SHAREDIR="@SHAREDIR@"
+
+SNEKHEX="$SHAREDIR/snek-lilypad328-@SNEK_VERSION@.hex"
+
+action="default"
+
+PORT="/dev/ttyACM0"
+
+mode=arg
+
+for i in "$@"; do
+    case "$mode" in
+	arg)
+	    case "$i" in
+		-hex|--hex)
+		    mode=hex
+		    ;;
+		-port|--port)
+		    mode=port
+		    ;;
+		*)
+		      echo "Usage: $0 {-hex snek-lilypad328.hex} {-port /dev/ttyACM0}" 1>&2
+		      exit 1
+		      ;;
+	    esac
+	    ;;
+	hex)
+	    SNEKHEX="$i"
+	    mode=arg
+	    ;;
+	port)
+	    PORT="$i"
+	    mode=arg
+    esac
+done
+
+avrdude -P $PORT -c arduino -b 38400 -p ATMEGA328P -D -U flash:w:"${SNEKHEX}"

--- a/snek-install.defs
+++ b/snek-install.defs
@@ -46,7 +46,8 @@ FIRMWARE ?= \
 	$(SNEK_PORTS)/uno/snek-uno-$(SNEK_VERSION).hex \
 	$(SNEK_PORTS)/xiao/snek-xiao-$(SNEK_VERSION).uf2 \
 	$(SNEK_PORTS_HIFIVE1REVB) $(SNEK_PORTS_ESP32) \
-	$(SNEK_PORTS_NANO_EVERY)
+	$(SNEK_PORTS_NANO_EVERY) \
+	$(SNEK_PORTS)/lilypad328/snek-lilypad328-$(SNEK_VERSION).hex
 
 USBFIRMWARE ?= \
 	$(SNEK_PORTS)/nano33iot/update-bootloader-nano33iot.ino \


### PR DESCRIPTION
Adding LilyPad Arduino 328 as additional "port" based on Uno.

I'm running LilyPad off 3V and 8MHz so I built bootloader and Snek to talk at only 38400 bps.

Creating PR as draft so
a. You can give feedback on using Uno approach etc.
b. I can continue to do some testing, including serial at 115.2k.