### PR TITLE
Add bigger duemilanove and uno ports

### DIFF
--- a/ports/duemilanove-big/.gitignore
+++ b/ports/duemilanove-big/.gitignore
@@ -1,0 +1,5 @@
+snek-duemilanove-big-*.elf
+snek-duemilanove-big-*.map
+snek-duemilanove-big-*.hex
+snek-duemilanove-big-install
+snek-duemilanove-big-install.1

--- a/ports/duemilanove-big/Makefile
+++ b/ports/duemilanove-big/Makefile
@@ -1,0 +1,62 @@
+#
+# Copyright © 2020 Keith Packard <keithp@keithp.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+
+vpath %.in ../duemilanove-big
+
+BOARD?=duemilanove-big
+CBOARD?=Duemilanove-big
+UBOARD?=DUEMILANOVE-BIG
+PORT?=/dev/ttyUSB0
+INSTALLER?=0
+
+ATMEGA_FLASH_SIZE=0x8000
+
+SNEK_ATMEGA_SRC_EXTRA = \
+	snek-input.c
+
+SNEK_ATMEGA_BUILTINS_EXTRA = \
+	snek-input.builtin
+
+include ../duemilanove/Makefile
+
+all:: snek-$(BOARD)-install snek-$(BOARD)-install.1
+
+snek-$(BOARD)-install: snek-duemilanove-big-install.in
+	$(SNEK_ATMEGA_SED) $^ > $@
+	chmod +x $@
+
+install:: $(HEX)
+	install -d $(DESTDIR)$(SHAREDIR)
+	install -m 0644 $(HEX) $(DESTDIR)$(SHAREDIR)
+
+install:: snek-$(BOARD)-install snek-$(BOARD)-install.1
+	install -d $(DESTDIR)$(BINDIR)
+	install snek-$(BOARD)-install $(DESTDIR)$(BINDIR)
+	install -d $(DESTDIR)$(MANDIR)/man1
+	install -m 0644 snek-$(BOARD)-install.1 $(DESTDIR)$(MANDIR)/man1
+
+clean::
+	rm -f snek-$(BOARD)-install snek-$(BOARD)-install.1
+	rm -f *.hex *.elf *.map
+	rm -f ao-product.h
+
+uninstall::
+
+ISP=avrisp2
+
+load: $(HEX) snek-$(BOARD)-install
+	./snek-$(BOARD)-install -quick -isp $(ISP) -hex $(HEX) load
+
+snek-$(BOARD)-install.1: snek-duemilanove-big-install.1.in
+	$(SNEK_ATMEGA_SED) $^ > $@

--- a/ports/duemilanove-big/snek-duemilanove-big-install.1.in
+++ b/ports/duemilanove-big/snek-duemilanove-big-install.1.in
@@ -1,0 +1,54 @@
+.\"
+.\" Copyright © 2021 Keith Packard <keithp@keithp.com>
+.\"
+.\" This program is free software; you can redistribute it and/or modify
+.\" it under the terms of the GNU General Public License as published by
+.\" the Free Software Foundation, either version 3 of the License, or
+.\" (at your option) any later version.
+.\"
+.\" This program is distributed in the hope that it will be useful, but
+.\" WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+.\" General Public License for more details.
+.\"
+.TH SNEK-@UBOARD@-INSTALL 1 "snek-@BOARD@-install" ""
+.SH NAME
+snek-@BOARD@-big-install \- Install larger version of Snek to
+Arduino ATmega328 board
+.SH SYNOPSIS
+.B "snek-@BOARD@-install" [OPTION]... [COMMAND]
+.SH DESCRIPTION
+.I snek-@BOARD@-install
+installs the larger version Snek programming language on an Arduino
+board with an ATmega328, overwriting the boot loader. This
+version of snek provides support for a few extra
+functions, 'input', 'float' and 'int'. As a consequence, it does not
+leave room for the Optiboot loader and must be flashed using a
+separate programmer dongle.
+.SH OPTIONS
+.TP
+\-isp <ISP model>
+Specifies the programmer to use, common options are 'usbtiny'
+and 'avrisp2'. The default is 'usbtiny'.
+.TP
+\-hex <snek.hex>
+Specifies the hex file to load to the board. The default is the
+currently installed version of Snek.
+.SH COMMANDS
+.TP
+fuseload
+Sets the target fuse bits for Snek usage and then loads Snek to the
+device. This is the default command
+.TP
+load
+Loads Snek to the device without first setting the fuse bits. Snek
+will not work correctly if the fuse bits are not set correctly, so
+only do this if the target has already had the fuse bits set correctly.
+.TP
+fuse
+Sets the target fuse bits suitable for Snek usage. You must do this
+before Snek will work on the target device, although you may do it
+before or after loading the Snek system. You only need to do this once
+per board.
+.SH AUTHOR
+Keith Packard

--- a/ports/duemilanove-big/snek-duemilanove-big-install.in
+++ b/ports/duemilanove-big/snek-duemilanove-big-install.in
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+SHAREDIR="@SHAREDIR@"
+
+SNEKBIGBASE="$SHAREDIR/snek-@BOARD@"
+SNEKBIGREST="-@SNEK_VERSION@.hex"
+SNEKBIG="$SNEKBIGBASE""$SNEKBIGREST"
+
+action="fuseload"
+
+ISP=usbtiny
+
+mode=arg
+
+verify=""
+
+for i in "$@"; do
+    case "$mode" in
+	arg)
+	    case "$i" in
+		fuse|load|fuseload)
+		    action="$i"
+		    ;;
+		-isp|--isp)
+		    mode=isp
+		    ;;
+		-hex|--hex)
+		    mode=hex
+		    ;;
+		-quick)
+		    verify="-V"
+		    ;;
+		*)
+		      echo "Usage: $0 {-isp usbtiny} {-isp avrisp2} {-hex snek-uduino.hex} {fuseload|load|fuse}" 1>&2
+		      exit 1
+		      ;;
+	    esac
+	    ;;
+	isp)
+	    ISP="$i"
+	    mode=arg
+	    ;;
+	hex)
+	    SNEKBIG="$i"
+	    mode=arg
+	    ;;
+    esac
+done
+
+FUSES="-U lfuse:w:0xff:m -U hfuse:w:0x91:m -U efuse:w:0xfd:m"
+
+case "$action" in
+    fuse)
+	avrdude -V -c $ISP -p m328 -u $FUSES
+	;;
+    fuseload)
+	avrdude -V -c $ISP -p m328 -u $FUSES && avrdude $verify -c $ISP -p m328 -U flash:w:"${SNEKBIG}"
+	;;
+    load)
+	avrdude $verify -c $ISP -p m328 -U flash:w:"${SNEKBIG}"
+	;;
+esac

--- a/ports/duemilanove/Makefile
+++ b/ports/duemilanove/Makefile
@@ -18,6 +18,8 @@ BOARD?=duemilanove
 CBOARD?=Duemilanove
 UBOARD?=DUEMILANOVE
 PORT?=/dev/ttyUSB0
+INSTALLER?=1
+ATMEGA_FLASH_SIZE?=0x7e00
 
 include $(SNEK_ATMEGA)/snek-atmega.defs
 
@@ -26,6 +28,7 @@ SNEK_LOCAL_VPATH = $(SNEK_ATMEGA)
 SNEK_LOCAL_SRC = \
 	snek-pow.c \
 	snek-328p.c \
+	$(SNEK_ATMEGA_SRC_EXTRA) \
 	$(SNEK_ATMEGA_SRC)
 
 SNEK_LOCAL_INC = \
@@ -33,6 +36,7 @@ SNEK_LOCAL_INC = \
 
 SNEK_LOCAL_BUILTINS = \
 	$(SNEK_ATMEGA_BUILTINS) \
+	$(SNEK_ATMEGA_BUILTINS_EXTRA) \
 	snek-328p.builtin
 
 include $(SNEK_ROOT)/snek-install.defs
@@ -56,10 +60,10 @@ OPT=-Os -frename-registers -funsigned-char -fno-jump-tables -mcall-prologues
 CFLAGS=$(OPT) -DF_CPU=16000000UL -mmcu=atmega328p -I. -I$(SNEK_LOCAL_VPATH) -g $(SNEK_CFLAGS) -Waddr-space-convert
 LDFLAGS=$(SNEK_LDFLAGS) \
 	-Wl,-uvfprintf -lprintf_flt -lm \
-	-Wl,--defsym -Wl,__TEXT_REGION_LENGTH__=0x7e00 \
+	-Wl,--defsym -Wl,__TEXT_REGION_LENGTH__=$(ATMEGA_FLASH_SIZE) \
 	-Wl,-Map=$(MAP)
 
-all:: $(HEX) snek-$(BOARD)-install snek-$(BOARD)-install.1
+all:: $(HEX)
 
 $(HEX): $(ELF)
 	avr-objcopy -O ihex -R .eeprom $^ $@
@@ -67,6 +71,9 @@ $(HEX): $(ELF)
 $(ELF): $(SNEK_OBJ)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 	@gawk '/__data_load_end/{printf("ROM used: %d bytes\n", strtonum($$1)); }' $(MAP)
+
+ifeq ($(INSTALLER),1)
+all:: snek-$(BOARD)-install snek-$(BOARD)-install.1
 
 snek-$(BOARD)-install: snek-duemilanove-install.in
 	$(SNEK_ATMEGA_SED) $^ > $@
@@ -85,6 +92,8 @@ install: snek-$(BOARD)-install $(HEX) snek-$(BOARD)-install.1
 	install -m 0644 $(HEX) $(DESTDIR)$(SHAREDIR)
 	install -d $(DESTDIR)$(MANDIR)/man1
 	install -m 0644 snek-$(BOARD)-install.1 $(DESTDIR)$(MANDIR)/man1
+
+endif
 
 clean::
 	rm -f *.elf *.hex *.map snek-$(BOARD)-install snek-$(BOARD)-install.1

--- a/ports/uno-big/.gitignore
+++ b/ports/uno-big/.gitignore
@@ -1,0 +1,5 @@
+snek-uno-big-*.elf
+snek-uno-big-*.map
+snek-uno-big-*.hex
+snek-uno-big-install
+snek-uno-big-install.1

--- a/ports/uno-big/Makefile
+++ b/ports/uno-big/Makefile
@@ -1,0 +1,20 @@
+#
+# Copyright © 2020 Keith Packard <keithp@keithp.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+
+BOARD?=uno-big
+CBOARD?=Uno-big
+UBOARD?=UNO-BIG
+PORT?=/dev/ttyACM0
+
+include ../duemilanove-big/Makefile

--- a/snek-install.defs
+++ b/snek-install.defs
@@ -28,6 +28,7 @@ endif
 FIRMWARE ?= \
 	$(SNEK_PORTS)/crickit/snek-crickit-$(SNEK_VERSION).uf2 \
 	$(SNEK_PORTS)/duemilanove/snek-duemilanove-$(SNEK_VERSION).hex \
+	$(SNEK_PORTS)/duemilanove-big/snek-duemilanove-big-$(SNEK_VERSION).hex \
 	$(SNEK_PORTS)/ev3/snek-ev3-$(SNEK_VERSION) \
 	$(SNEK_PORTS)/feather/snek-feather-$(SNEK_VERSION).uf2 \
 	$(SNEK_PORTS)/grove/snek-grove-$(SNEK_VERSION).hex \
@@ -44,6 +45,7 @@ FIRMWARE ?= \
 	$(SNEK_PORTS)/snekboard/snek-board-$(SNEK_VERSION).uf2 \
 	$(SNEK_PORTS)/uduino/snek-uduino-$(SNEK_VERSION).hex \
 	$(SNEK_PORTS)/uno/snek-uno-$(SNEK_VERSION).hex \
+	$(SNEK_PORTS)/uno-big/snek-uno-big-$(SNEK_VERSION).hex \
 	$(SNEK_PORTS)/xiao/snek-xiao-$(SNEK_VERSION).uf2 \
 	$(SNEK_PORTS_HIFIVE1REVB) $(SNEK_PORTS_ESP32) \
 	$(SNEK_PORTS_NANO_EVERY)


### PR DESCRIPTION
These overwrite the bootloader, requiring a dongle to flash them. This allows adding all of the input builtins to the image.
