### PR TITLE
Accept missing newline at end of file

### DIFF
--- a/snek-gram.ll
+++ b/snek-gram.ll
@@ -89,7 +89,10 @@ stat		: simple-stat
 		  compound-stat
 		| NL
 		;
-simple-stat	: @{ snek_code_add_line(); }@ small-stat small-stats-p NL
+simple-stat	: @{ snek_code_add_line(); }@ small-stat small-stats-p nl-or-end
+		;
+nl-or-end	: NL
+		| END
 		;
 small-stats-p	: SEMI small-stat small-stats-p
 		|


### PR DESCRIPTION
Accept either 'NL' or 'END' at the end of a simple statement so that
programs that end without a NL will still work correctly.

Closes #39

Signed-off-by: Keith Packard <keithp@keithp.com>