### PR TITLE
Correct stack usage during chained comparison operations

### DIFF
--- a/snek-exec.c
+++ b/snek-exec.c
@@ -771,9 +771,11 @@ snek_exec(snek_code_t *code_in)
 			case snek_op_chain_le:
 				op -= (snek_op_chain_eq - snek_op_eq);
 				snek_poly_t r = snek_binary(snek_stack_pick(0), op, snek_a, false);
+				snek_stack_drop(1);
 				if (!snek_poly_true(r)) {
 					snek_a = r;
 					memcpy(&ip, &snek_code->code[ip], sizeof (snek_offset_t));
+					push = false;
 				} else
 					ip += sizeof (snek_offset_t);
 				break;

--- a/snek-gram.ll
+++ b/snek-gram.ll
@@ -326,8 +326,10 @@ expr-cmp	: expr-lor
 		  expr-cmp-p
 			@{
 				snek_offset_t cmp_off = value_pop().offset;
-				if (cmp_off)
+				if (cmp_off) {
 					snek_code_patch_forward(cmp_off, snek_code_current(), snek_forward_cmp, snek_code_current());
+					snek_code_add_op(snek_op_nop);
+				}
 			}@
 		;
 expr-cmp-p	: cmpop

--- a/test/pass-chain-op.py
+++ b/test/pass-chain-op.py
@@ -87,3 +87,11 @@ assert not ("a" > "b" == "c")
 assert not ("a" > "b" != "c")
 assert not ("a" > "b" >= "c")
 assert not ("a" > "b" > "c")
+
+
+def add(a, b):
+    return a + b
+
+
+assert add(1 == 2 != 0, 3) == 3
+assert add(1 == 1 != 1, 4) == 4


### PR DESCRIPTION
Chained comparison operators (a < b < c) use a "short-circuit"
mechanism much like the boolean operators 'and' and 'or'. This
requires some fancy hacks in snek and there were a few mistakes:

 1. The left-hand operand ('a') was left on the stack

 2. The second operator (b < c) would set the 'push' bit, which is on
    the first comparison operator so that 'b' would be on the
    stack. If the first comparison was false, that push wouldn't be
    appropriate. So, we reset the 'push' flag when branching.

 3. We need an instruction to land on after branching that can get the
    'push' bit set in case the following operations need it. So we
    insert a 'nop' there, just like the short-circuited 'and'/'or'
    does.

Also add some tests which detect these mistakes.

Signed-off-by: Keith Packard <keithp@keithp.com>

Closes #50 