### PR TITLE
Add Lilypad support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ described below.
 
  * [Arduino Nano Every](https://store.arduino.cc/usa/nano-every).
 
+ * [LilyPad Arduino 328](https://www.sparkfun.com/products/13342).
+   This port leaves out dictionaries and slices so that it has space
+   for the tone driver.
+
 ## To Do list
 
  * Convert parser from LL to SLR. The hope here is to reduce the
@@ -86,6 +90,12 @@ described below.
 ## Recent Changes
 
 Here's some places that have seen recent work
+
+ * [LilyPad Arduino 328](https://www.sparkfun.com/products/13342)
+   port. This is a round ATmega328p-based board designed for wearable
+   projects. This board runs at 8MHz, which can't run the serial port
+   at 115.2kbaud, so it runs at 57.6k instead. Thanks to Douglas
+   Fraser for this.
 
  * Support multiple baud rates in snekde, auto-detect baud rate when
    connecting to non-USB based devices.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ described below.
 
 Here's some places that have seen recent work
 
+ * Support multiple baud rates in snekde, auto-detect baud rate when
+   connecting to non-USB based devices.
+
  * Fix NaN comparisons and make dicts containing NaN keys work.
    [Jake Edge's article, “Revisiting NaNs in Python”](https://lwn.net/Articles/869231/)
    led to the discovery that Snek had several bugs in NaN

--- a/chips/atmega/snek-328p.c
+++ b/chips/atmega/snek-328p.c
@@ -137,7 +137,9 @@ pin_reg(uint8_t pin)
 {
 	if (pin < 8)
 		return &PIND;
-	return &PINB;
+	if (pin < 14)
+		return &PINB;
+	return &PINC;
 }
 
 static volatile uint8_t *

--- a/chips/atmega/snek-328p.c
+++ b/chips/atmega/snek-328p.c
@@ -362,6 +362,17 @@ snek_builtin_tone(snek_poly_t a)
 
 	return SNEK_NULL;
 }
+
+#ifdef SNEK_BUILTIN_tonefor
+snek_poly_t
+snek_builtin_tonefor(snek_poly_t a, snek_poly_t b)
+{
+	snek_builtin_tone(a);
+	snek_builtin_on();
+	snek_builtin_time_sleep(b);
+	return snek_builtin_tone(SNEK_ZERO);
+}
+#endif
 #endif
 
 snek_poly_t

--- a/chips/atmega/snek-328p.c
+++ b/chips/atmega/snek-328p.c
@@ -27,7 +27,7 @@ static uint32_t	on_pins;
 /* digital pins all use PULL_UP by default */
 static uint32_t pull_pins = 0x03fff;
 
-#ifdef SNEK_TONE
+#ifdef SNEK_BUILTIN_tone
 static uint8_t 	tccr0a;
 static uint8_t	tccr0b;
 
@@ -312,7 +312,7 @@ set_out(uint8_t pin)
 	return SNEK_NULL;
 }
 
-#ifdef SNEK_TONE
+#ifdef SNEK_BUILTIN_tone
 /* Output tone on D5 */
 snek_poly_t
 snek_builtin_tone(snek_poly_t a)
@@ -458,7 +458,7 @@ snek_poly_t
 snek_builtin_stopall(void)
 {
 	uint8_t p;
-#ifdef SNEK_TONE
+#ifdef SNEK_builtin_tone
 	tcc0_reset();
 #endif
 	for (p = 0; p < NUM_PIN; p++)

--- a/chips/atmega/snek-atmega-serial.c
+++ b/chips/atmega/snek-atmega-serial.c
@@ -92,7 +92,7 @@ ring_get(uart_ring_t *ring)
 	return c;
 }
 
-static bool
+static bool __attribute__((noinline))
 ring_put(uart_ring_t *ring, uint8_t c)
 {
 	if (ring_full(ring))
@@ -140,7 +140,7 @@ _snek_uart_flow_do(void)
 	_snek_uart_tx_start();
 }
 
-static void
+static void __attribute__((noinline))
 _snek_uart_xon(void)
 {
 	if (rx_flow == FLOW_STOPPED && ring_empty(&rx_ring))
@@ -175,6 +175,10 @@ ISR(RX_vect)
 	case 'q' & 0x1f:
 		tx_flow = false;
 		_snek_uart_tx_start();
+		return;
+	case 't' & 0x1f:
+		while(!TX_EMPTY());
+		TX_DATA = c;
 		return;
 	}
 

--- a/chips/samd21/ao-usb-samd21.c
+++ b/chips/samd21/ao-usb-samd21.c
@@ -540,9 +540,6 @@ ao_usb_fifo_check(void)
 		if (ao_fifo_has_space(&ao_usb_rx_fifo, len)) {
 			uint16_t	i;
 
-#if AO_USB_OUT_HOOK
-			ao_usb_out_hook(buf, len);
-#endif
 			for (i = 0; i < len; i++)
 				ao_fifo_insert(&ao_usb_rx_fifo, buf[i]);
 			samd21_usb_ep_clr_ready(AO_USB_OUT_EP, next_which);
@@ -550,6 +547,9 @@ ao_usb_fifo_check(void)
 			ao_usb_out_rx_which = next_which;
 			ao_wakeup(AO_USB_OUT_SLEEP_ADDR);
 		}
+#if AO_USB_OUT_HOOK
+		ao_usb_out_hook(buf, len);
+#endif
 	}
 }
 #endif

--- a/doc/snek.adoc
+++ b/doc/snek.adoc
@@ -2460,19 +2460,24 @@ package for your machine and copy it to the snekboard file system.
 
 [%nonfacing]
 [appendix]
-= Snek on Arduino Duemilanove, Nano and Uno
+= Snek on Arduino Duemilanove, LilyPad, Nano and Uno
 
-There are two versions of Snek for these boards, the regular version
-and a “big” version. The regular version co-exists with the Optiboot
-bootloader which makes re-flashing with new versions of Snek
-convenient. The big version overwrites the boot loader to provide
-additional functionality.
+These boards are all based on the original Arduino ATMega 328
+processor. There are two versions of Snek for these boards: the
+regular version and a “big” version. The regular version co-exists
+with the Optiboot bootloader which makes re-flashing with new versions
+of Snek convenient. The big version overwrites the boot loader to
+provide additional functionality.
 
-Snek for the Duemilanove, Nano and Uno include the Common System,
-EEPROM, and GPIO functions. The “big” versions add the Input
-functions. They do not include the Math functions, nor the `pulldown`
-function. Snek for these boards provides pre-defined variables for all
-of the GPIO pins:(((Duemilanove)))(((Nano)))(((Uno)))(((Arduino)))
+Snek for these boards include the Common System, EEPROM, and GPIO
+functions. The “big” versions add the Input functions. They do not
+include the Math functions, nor the `pulldown` function. Snek for
+these boards provides pre-defined variables for all of the GPIO
+pins:(((Duemilanove)))(((LilyPad)))(((Nano)))(((Uno)))(((Arduino)))
+
+Snek for the LilyPad adds the 'tone' and 'tonefor' builtins, which
+send an audio tone to pin D5. To make space for this, support for
+Dictionaries was removed.
 
 D0 - D13::
 Digital input and output pins. By default, when used as input pins,
@@ -2487,7 +2492,7 @@ either a pull-up or pull-down resistor to the pin so that a
 disconnected pin will read an indeterminate value. Change this using
 `pullnone` or `pullup` functions.
 
-=== Installing Optiboot on the Duemilanove or Nano
+=== Installing Optiboot on ATMega 328 boards
 
 Snek nearly fills the ATMega 328P flash, leaving space only for the
 smaller optiboot loader. This loader is not usually installed on the
@@ -2498,31 +2503,42 @@ Use the Arduino IDE to install the Optiboot boot loader following
 instructions found on the
 link:https://github.com/Optiboot/optiboot[Optiboot web site].
 
-=== Installing Snek on the Duemilanove, Nano and Uno
+=== Installing Snek on ATMega 328 boards
 
 To install the regular version, once your board is ready to install
 snek, you can use avrdude to do that with Optiboot. On Linux, you can
-use either snek-duemilanove-install (for Duemilanove and Nano
-boards), or snek-uno-install (for Uno boards):
+use snek-duemilanove-install (for Duemilanove and Nano),
+snek-uno-install (for Uno), or snek-lilypad-install (for LilyPad).
 
 	$ snek-duemilanove-install
 
 or
 
+	$ snek-lilypad-install
+
+or
+
 	$ snek-uno-install
 
-On other hosts, you'll need to run 'avrdude' manually. For duemilanove or nano boards:
+On other hosts, you'll need to run 'avrdude' manually. For Duemilanove or Nano boards:
 
 [subs="verbatim,quotes,attributes,"]
 ----
 $ avrdude -pATMEGA328P -carduino -PCOM1 -b115200 -D -U flash:w:snek-duemilanove-{version}.hex:i
 ----
 
-For uno boards:
+For Uno boards:
 
 [subs="verbatim,quotes,attributes,"]
 ----
 $ avrdude -pATMEGA328P -carduino -PCOM1 -b115200 -D -U flash:w:snek-uno-{version}.hex:i
+----
+
+For LilyPad boards:
+
+[subs="verbatim,quotes,attributes,"]
+----
+$ avrdude -pATMEGA328P -carduino -PCOM1 -b57600 -D -U flash:w:snek-lilypad-{version}.hex:i
 ----
 
 Replace 'COM1' with the name of the serial port on your computer.

--- a/doc/snek.adoc
+++ b/doc/snek.adoc
@@ -2545,14 +2545,18 @@ Replace 'COM1' with the name of the serial port on your computer.
 
 To install the “big” version, you'll need to use a programming device,
 such as a usbtiny from Adafruit. Once connected, on Linux you can use
-snek-duemilanove-big-install (for Duemilanove or Nano boards) or
-snek-uno-big-install (for Uno boards):
+snek-duemilanove-big-install (for Duemilanove or Nano),
+snek-lilypad-big-install (for LilyPad), or snek-uno-big-install (for Uno):
 
 	$ snek-duemilanove-big-install
 
 or
 
-	$ snek-uno-install-big-install
+	$ snek-lilypad-install-big
+
+or
+
+	$ snek-uno-big-install
 
 On other hosts, you'll need to run 'avrdude' manually:
 
@@ -2560,6 +2564,14 @@ On other hosts, you'll need to run 'avrdude' manually:
 ----
 $ avrdude -V -c usbtiny -p m328 -u -U lfuse:w:0xff:m -U hfuse:w:0x91:m -U efuse:w:0xfd:m
 $ avrdude -c usbtiny -p m328 -U flash:w:snek-duemilanove-big-{version}.hex:i
+----
+
+or
+
+[subs="verbatim,quotes,attributes,"]
+----
+$ avrdude -V -c usbtiny -p m328 -u -U lfuse:w:0xff:m -U hfuse:w:0x91:m -U efuse:w:0xfd:m
+$ avrdude -c usbtiny -p m328 -U flash:w:snek-lilypad-big-{version}.hex:i
 ----
 
 or

--- a/ports/duemilanove-big/Makefile
+++ b/ports/duemilanove-big/Makefile
@@ -22,10 +22,10 @@ INSTALLER?=0
 
 ATMEGA_FLASH_SIZE=0x8000
 
-SNEK_ATMEGA_SRC_EXTRA = \
+SNEK_ATMEGA_SRC_EXTRA ?= \
 	snek-input.c
 
-SNEK_ATMEGA_BUILTINS_EXTRA = \
+SNEK_ATMEGA_BUILTINS_EXTRA ?= \
 	snek-input.builtin
 
 include ../duemilanove/Makefile

--- a/ports/duemilanove/Makefile
+++ b/ports/duemilanove/Makefile
@@ -12,6 +12,8 @@
 # General Public License for more details.
 #
 
+vpath %.in ../duemilanove
+
 SNEK_ROOT = ../..
 SNEK_ATMEGA = $(SNEK_ROOT)/chips/atmega
 BOARD?=duemilanove

--- a/ports/duemilanove/Makefile
+++ b/ports/duemilanove/Makefile
@@ -20,6 +20,8 @@ BOARD?=duemilanove
 CBOARD?=Duemilanove
 UBOARD?=DUEMILANOVE
 PORT?=/dev/ttyUSB0
+CLOCK?=16000000
+BAUD?=115200
 INSTALLER?=1
 ATMEGA_FLASH_SIZE?=0x7e00
 
@@ -47,6 +49,7 @@ SNEK_ATMEGA_SED=$(SNEK_SED) \
 	-e 's;@BOARD@;$(BOARD);g' \
 	-e 's;@UBOARD@;$(UBOARD);g' \
 	-e 's;@CBOARD@;$(CBOARD);g' \
+	-e 's;@BAUD@;$(BAUD);g' \
 	-e 's;@PORT@;$(PORT);g'
 
 SNEK_CFLAGS = $(SNEK_MOST_WARNINGS) $(SNEK_BASE_CFLAGS)
@@ -59,7 +62,7 @@ CC=avr-gcc
 
 OPT=-Os -frename-registers -funsigned-char -fno-jump-tables -mcall-prologues
 
-CFLAGS=$(OPT) -DF_CPU=16000000UL -mmcu=atmega328p -I. -I$(SNEK_LOCAL_VPATH) -g $(SNEK_CFLAGS) -Waddr-space-convert
+CFLAGS=$(OPT) -DUART_BAUD=$(BAUD) -DF_CPU=$(CLOCK)UL -mmcu=atmega328p -I. -I$(SNEK_LOCAL_VPATH) -g $(SNEK_CFLAGS) -Waddr-space-convert
 LDFLAGS=$(SNEK_LDFLAGS) \
 	-Wl,-uvfprintf -lprintf_flt -lm \
 	-Wl,--defsym -Wl,__TEXT_REGION_LENGTH__=$(ATMEGA_FLASH_SIZE) \

--- a/ports/duemilanove/snek-duemilanove-install.in
+++ b/ports/duemilanove/snek-duemilanove-install.in
@@ -36,4 +36,4 @@ for i in "$@"; do
     esac
 done
 
-avrdude -P $PORT -c arduino -b 115200 -p ATMEGA328P -D -U flash:w:"${SNEKHEX}"
+avrdude -P $PORT -c arduino -b @BAUD@ -p ATMEGA328P -D -U flash:w:"${SNEKHEX}"

--- a/ports/grove/snek-grove.builtin
+++ b/ports/grove/snek-grove.builtin
@@ -16,7 +16,6 @@ accel, 0
 float, 1
 int, 1
 tone, 1
-#define SNEK_TONE
 #define SNEK_POOL		800
 #define PARSE_STACK_SIZE	64
 #define SNEK_STACK		16

--- a/ports/grove/snek-grove.builtin
+++ b/ports/grove/snek-grove.builtin
@@ -16,6 +16,7 @@ accel, 0
 float, 1
 int, 1
 tone, 1
+tonefor, 2
 #define SNEK_POOL		800
 #define PARSE_STACK_SIZE	64
 #define SNEK_STACK		16

--- a/ports/lilypad-big/.gitignore
+++ b/ports/lilypad-big/.gitignore
@@ -1,0 +1,5 @@
+snek-lilypad-big-*.elf
+snek-lilypad-big-*.hex
+snek-lilypad-big-*.map
+snek-lilypad-big-install
+snek-lilypad-big-install.1

--- a/ports/lilypad-big/Makefile
+++ b/ports/lilypad-big/Makefile
@@ -1,0 +1,27 @@
+#
+# Copyright © 2020 Keith Packard <keithp@keithp.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+
+SNEK_NO_DICT=1
+BOARD=lilypad-big
+CBOARD=LilyPad-big
+UBOARD=LILYPAD-BIG
+PORT=/dev/ttyUSB0
+BAUD=57600
+CLOCK=8000000
+
+SNEK_ATMEGA_BUILTINS_EXTRA = \
+	snek-tone.builtin \
+	snek-input.builtin
+
+include ../duemilanove-big/Makefile

--- a/ports/lilypad/.gitignore
+++ b/ports/lilypad/.gitignore
@@ -1,0 +1,5 @@
+snek-lilypad-*.elf
+snek-lilypad-*.hex
+snek-lilypad-*.map
+snek-lilypad-install
+snek-lilypad-install.1

--- a/ports/lilypad/Makefile
+++ b/ports/lilypad/Makefile
@@ -1,0 +1,27 @@
+#
+# Copyright © 2020 Keith Packard <keithp@keithp.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+
+SNEK_NO_DICT=1
+SNEK_NO_SLICE=1
+BOARD=lilypad
+CBOARD=LilyPad
+UBOARD=LILYPAD
+PORT=/dev/ttyUSB0
+BAUD=57600
+CLOCK=8000000
+
+SNEK_ATMEGA_BUILTINS_EXTRA = \
+	snek-tone.builtin
+
+include ../duemilanove/Makefile

--- a/ports/uno/Makefile
+++ b/ports/uno/Makefile
@@ -12,8 +12,6 @@
 # General Public License for more details.
 #
 
-vpath %.in ../duemilanove
-
 BOARD=uno
 CBOARD=Uno
 UBOARD=UNO

--- a/ports/uno/Makefile
+++ b/ports/uno/Makefile
@@ -18,11 +18,3 @@ UBOARD=UNO
 PORT=/dev/ttyACM0
 
 include ../duemilanove/Makefile
-
-all:: snek-uno-install.in
-
-snek-uno-install.in: snek-duemilanove-install.in
-	sed -e 's;@BOARD@;$(BOARD);g' \
-	-e 's;@UBOARD@;$(UBOARD);g' \
-	-e 's;@CBOARD@;$(CBOARD);g' \
-	-e 's;@PORT@;$(PORT);g' $^ > $@

--- a/snek-install.defs
+++ b/snek-install.defs
@@ -35,6 +35,7 @@ FIRMWARE ?= \
 	$(SNEK_PORTS)/itsybitsy3v/snek-itsybitsy3v-$(SNEK_VERSION).hex \
 	$(SNEK_PORTS)/itsybitsy5v/snek-itsybitsy5v-$(SNEK_VERSION).hex \
 	$(SNEK_PORTS)/itsybitsym0/snek-itsybitsym0-$(SNEK_VERSION).uf2 \
+	$(SNEK_PORTS)/lilypad/snek-lilypad-$(SNEK_VERSION).hex \
 	$(SNEK_PORTS)/mega/snek-mega-$(SNEK_VERSION).hex \
 	$(SNEK_PORTS)/metrom0/snek-metrom0-$(SNEK_VERSION).uf2 \
 	$(SNEK_PORTS)/nano33iot/snek-nano33iot-$(SNEK_VERSION).uf2 \

--- a/snek-install.defs
+++ b/snek-install.defs
@@ -36,6 +36,7 @@ FIRMWARE ?= \
 	$(SNEK_PORTS)/itsybitsy5v/snek-itsybitsy5v-$(SNEK_VERSION).hex \
 	$(SNEK_PORTS)/itsybitsym0/snek-itsybitsym0-$(SNEK_VERSION).uf2 \
 	$(SNEK_PORTS)/lilypad/snek-lilypad-$(SNEK_VERSION).hex \
+	$(SNEK_PORTS)/lilypad-big/snek-lilypad-big-$(SNEK_VERSION).hex \
 	$(SNEK_PORTS)/mega/snek-mega-$(SNEK_VERSION).hex \
 	$(SNEK_PORTS)/metrom0/snek-metrom0-$(SNEK_VERSION).uf2 \
 	$(SNEK_PORTS)/nano33iot/snek-nano33iot-$(SNEK_VERSION).uf2 \

--- a/snekde/snekde.py
+++ b/snekde/snekde.py
@@ -49,6 +49,10 @@ snek_cur_path = None
 
 snek_debug_file = False
 
+baud_rates = [115200, 57600]
+
+baud_selection = 0
+
 
 def snek_debug(message):
     global snek_debug_file
@@ -185,7 +189,7 @@ class SnekDevice:
     # that gets data that are read
     #
 
-    def __init__(self, port, interface):
+    def __init__(self, port, interface, rate=115200):
         self.interface = interface
         self.device = port.device
 
@@ -195,7 +199,6 @@ class SnekDevice:
         self.synchronous_put = True
         self.synchronous_limit = 16
 
-        rate = 115200
         for port_mod in port_mods:
             if port_mod in port.description or port_mod in port.hwid:
                 if "async" in port_mods[port_mod]:
@@ -344,6 +347,9 @@ class SnekDevice:
 
     def command(self, data, intr="\x03"):
         self.write("\x0e" + intr + data)
+
+    def set_baud(self, baud):
+        self.serial.baudrate = baud
 
 
 class EditWin:
@@ -1112,6 +1118,7 @@ help_text = (
     ("F5", "Load"),
     ("F6", "Save"),
     ("F7", "Switch"),
+    ("F8", "Rate"),
 )
 
 # Paint the function key help text and the separator line
@@ -1128,6 +1135,7 @@ def screen_paint():
     device_name = "<no device>"
     if snek_device:
         device_name = snek_device.device
+    device_name = "%s %d" % (device_name, baud_rates[baud_selection])
     device_col = snek_cols - len(device_name)
     if device_col < 0:
         device_col = 0
@@ -1190,19 +1198,41 @@ def screen_fini():
     curses.endwin()
 
 
+def switch_baud():
+    global snek_device, baud_selection, baud_rates
+    baud_selection = (baud_selection + 1) % len(baud_rates)
+    if snek_device:
+        snek_device.set_baud(baud_rates[baud_selection])
+    screen_paint()
+
+
 def snekde_open_device():
-    global snek_device, snek_monitor
+    global snek_device, snek_monitor, baud_selection, baud_rates
     dialog = GetPortWin()
     port = dialog.run_dialog()
     if not port:
         return
     try:
-        device = SnekDevice(port, snek_monitor)
+        device = SnekDevice(port, snek_monitor, rate=baud_rates[baud_selection])
         device.start()
         if snek_device:
             snek_device.close()
             del snek_device
         snek_device = device
+
+        # Attempt to auto-baud synchronous devices
+        if snek_device.synchronous_put:
+            old_baud = baud_selection
+            for i in range(len(baud_rates)):
+                baud_selection = i
+                # snek_debug("try baud %d" % baud_rates[i])
+                snek_device.set_baud(baud_rates[baud_selection])
+                if snek_monitor.ping():
+                    break
+            else:
+                baud_selection = old_baud
+                snek_device.set_baud(baud_rates[baud_selection])
+
         screen_paint()
     except OSError as e:
         message = e.strerror
@@ -1333,6 +1363,8 @@ def run():
                 snek_current_window = snek_repl_win
             else:
                 snek_current_window = snek_edit_win
+        elif ch == curses.KEY_F8 or ch == ord("8") | 0x80:
+            switch_baud()
         elif ch == ord("\n"):
             if snek_current_window is snek_edit_win:
                 snek_current_window.dispatch(ch)
@@ -1378,6 +1410,7 @@ class SnekMonitor:
         global snek_lock
         self.cv = threading.Condition(snek_lock)
         self.ack = threading.Condition(snek_lock)
+        self.dc4 = threading.Condition(snek_lock)
         self.getting_text = False
 
     # Synchronize with the remote device by sending ENQ and
@@ -1391,6 +1424,12 @@ class SnekMonitor:
             snek_device.serial.write(b"\x05")
             self.ack.wait(1)
             # snek_debug('sync done')
+
+    def ping(self):
+        global snek_lock
+        snek_device.serial.write(b"\x14")
+        ret = self.dc4.wait(0.1)
+        return ret
 
     # Reading text to snek_edit_win instead of snek_repl_win
 
@@ -1427,6 +1466,13 @@ class SnekMonitor:
                 with snek_lock:
                     # snek_debug('notify ack')
                     self.ack.notify_all()
+
+            # DC4 - device has seen DC4
+            elif b == b"\x14":
+                # snek_debug("receive PING")
+                with snek_lock:
+                    # snek_debug("notify PING")
+                    self.dc4.notify_all()
 
             # Ignore all control chars other than newline
             elif b < b"\x20" and b != b"\n":


### PR DESCRIPTION
LilyPad includes the standard I/O bits plus the tone functions to drive the LilyPad speaker.

This required adding 57600 baud support as the LilyPad runs at 8MHz and cannot run the serial port at 115.2kbaud.