### PR TITLE
Add some more details about build requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,19 @@ To build Snek you need these dependencies:
 
 On Debian unstable, you can get everything from the main archive:
 
-	# apt install lola gcc-avr avr-libc python3-serial \
+	# apt install lola gcc-avr avr-libc python3-serial gawk \
           gcc-arm-none-eabi gcc-riscv64-unknown-elf libreadline-dev \
 	  picolibc-arm-none-eabi picolibc-riscv64-unknown-elf
+
+Debian stable has too old a version of lola, so if you're using that,
+you'll need to install lola from the git repository above.
+
+The snek build scripts use the GNU awk implementation, `gawk`,
+including a GNU extension, `strtonum`, which is not available in other
+awk implementations. It's not critical to compiling the code as it's
+only used to print out ROM usage for AVR targets so you can tell how
+much space is still available, but if you don't have gawk, you will
+get build failures.
 
 ### Building and install
 

--- a/snek-builtin.py
+++ b/snek-builtin.py
@@ -96,7 +96,7 @@ class SnekBuiltin:
             if self.value[0].isdigit():
                 return "(snek_poly_t)(float)%s" % self.value
             return self.value
-        name = self.name;
+        name = self.name
         if self.init is not None:
             name = self.init
         return "snek_builtin_%s" % (name.replace(".", "_"))


### PR DESCRIPTION
Note that a current version of lola and the GNU awk version (gawk) are
required to build Snek.

Closes #61 

Signed-off-by: Keith Packard <keithp@keithp.com>