### PR TITLE
Return '' when just <nl> is provided to 'input'

### DIFF
--- a/chips/avr/ao-arch.h
+++ b/chips/avr/ao-arch.h
@@ -47,7 +47,7 @@
 
 #define ao_arch_reboot()	/* XXX */
 
-#define ao_arch_nop()		asm("nop")
+#define ao_arch_nop()		__asm__("nop")
 
 #define ao_arch_interrupt(n)	/* nothing */
 

--- a/chips/avr/snek-avr.defs
+++ b/chips/avr/snek-avr.defs
@@ -52,7 +52,7 @@ OPT=-Os -frename-registers -funsigned-char -fno-jump-tables -mcall-prologues
 SNEK_CFLAGS = $(SNEK_MOST_WARNINGS) $(SNEK_BASE_CFLAGS)
 
 AO_CFLAGS=\
-	-std=gnu99 $(OPT) -g
+	-std=c99 $(OPT) -g
 
 AVR_CFLAGS=-DF_CPU=$(AVR_CLOCK) -mmcu=atmega32u4 -g $(SNEK_CFLAGS) -Waddr-space-convert \
 	-I. -I$(SNEK_PORT) -I$(SNEK_AVR) -I$(SNEK_AO) -I$(SNEK_ROOT) $(AO_CFLAGS)

--- a/chips/qemu/snek-qemu.defs
+++ b/chips/qemu/snek-qemu.defs
@@ -37,7 +37,7 @@ PICOLIBC_CFLAGS= \
 OPT?=-Os
 
 CFLAGS=$(ARCH_CFLAGS) --oslib=semihost --crt0=semihost \
-	-std=gnu99 $(OPT) -g \
+	-std=c18 $(OPT) -g \
 	-I. -I$(SNEK_QEMU) -I$(SNEK_ROOT) $(PICOLIBC_CFLAGS) $(SNEK_CFLAGS)
 
 LDFLAGS=$(SNEK_LDFLAGS) $(CFLAGS) -n

--- a/chips/samd21/ao-arch-funcs.h
+++ b/chips/samd21/ao-arch-funcs.h
@@ -111,25 +111,25 @@ typedef uint32_t	ao_arch_irq_t;
 static inline uint32_t
 ao_arch_irqsave(void) {
 	uint32_t	primask;
-	asm("mrs %0,primask" : "=&r" (primask));
+	__asm__("mrs %0,primask" : "=&r" (primask));
 	ao_arch_block_interrupts();
 	return primask;
 }
 
 static inline void
 ao_arch_irqrestore(uint32_t primask) {
-	asm("msr primask,%0" : : "r" (primask));
+	__asm__("msr primask,%0" : : "r" (primask));
 }
 
 static inline void
 ao_arch_memory_barrier(void) {
-	asm volatile("" ::: "memory");
+	__asm__ volatile("" ::: "memory");
 }
 
 #define ao_arch_wait_interrupt() do {				\
-		asm("\twfi\n");					\
+		__asm__("\twfi\n");					\
 		ao_arch_release_interrupts();			\
-		asm(".global ao_idle_loc\nao_idle_loc:");	\
+		__asm__(".global ao_idle_loc\nao_idle_loc:");	\
 		ao_arch_block_interrupts();			\
 	} while (0)
 

--- a/chips/samd21/ao-arch.h
+++ b/chips/samd21/ao-arch.h
@@ -35,10 +35,10 @@
 	(samd21_scb.aircr = ((SAMD21_SCB_AIRCR_VECTKEY_KEY << SAMD21_SCB_AIRCR_VECTKEY) | \
 			  (1 << SAMD21_SCB_AIRCR_SYSRESETREQ)))
 
-#define ao_arch_nop()		asm("nop")
+#define ao_arch_nop()		__asm__("nop")
 #define ao_arch_interrupt(n)	/* nothing */
-#define ao_arch_block_interrupts()	asm("cpsid i")
-#define ao_arch_release_interrupts()	asm("cpsie i")
+#define ao_arch_block_interrupts()	__asm__("cpsid i")
+#define ao_arch_release_interrupts()	__asm__("cpsie i")
 
 /*
  * ao_timer.c

--- a/chips/samd21/snek-samd21.defs
+++ b/chips/samd21/snek-samd21.defs
@@ -75,7 +75,7 @@ PICOLIBC_CFLAGS= \
 OPT?=-Os
 
 AO_CFLAGS=\
-	-std=gnu99 $(OPT) -g
+	-std=c18 $(OPT) -g
 
 SAMD21_CFLAGS=-mlittle-endian -mcpu=cortex-m0 -mthumb\
 	-I$(SNEK_SAMD21) -I$(SNEK_AO) -I$(SNEK_ROOT) -I. $(AO_CFLAGS) $(PICOLIBC_CFLAGS)

--- a/ports/hifive1revb/Makefile
+++ b/ports/hifive1revb/Makefile
@@ -56,7 +56,7 @@ WARN_FLAGS=-Wall -Wextra -Wcast-align \
 	-Wno-maybe-uninitialized
 
 AO_CFLAGS=\
-	-std=gnu99 $(WARN_FLAGS) $(OPT) -g
+	-std=c18 $(WARN_FLAGS) $(OPT) -g
 
 HIFIVE1REVB_CFLAGS=-march=rv32imac -mabi=ilp32 \
 	-I. -I$(SNEK_ROOT) -I$(FREEDOM_METAL_INC) $(PICOLIBC_CFLAGS)

--- a/snek-input.c
+++ b/snek-input.c
@@ -23,7 +23,7 @@ snek_builtin_input(uint8_t nposition, uint8_t nnamed, snek_poly_t *args)
 {
 	char		in[2] = {0, 0};
 	int		c;
-	snek_poly_t	s = SNEK_NULL;
+	snek_poly_t	s = snek_string_to_poly(snek_alloc(1));
 
 	while (nposition--) {
 		snek_poly_t arg = *args++;
@@ -34,12 +34,8 @@ snek_builtin_input(uint8_t nposition, uint8_t nnamed, snek_poly_t *args)
 	(void) nnamed;
 	snek_in_input = true;
 	while ((c = getchar()) != '\n' && c != EOF) {
-		if (snek_is_null(s)) {
-			s = snek_string_make(c);
-		} else {
-			in[0] = c;
-			s = snek_string_cat(snek_poly_to_string(s), in);
-		}
+		in[0] = c;
+		s = snek_string_cat(snek_poly_to_string(s), in);
 	}
 	snek_in_input = false;
 	return s;

--- a/snek-pow.c
+++ b/snek-pow.c
@@ -19,7 +19,7 @@
 #include "snek.h"
 #include <math.h>
 
-#ifdef AVR
+#ifdef __AVR__
 #define float double
 #endif
 


### PR DESCRIPTION
That's what Python does. Snek's behavior of returning None didn't match.

Closes #64 

Signed-off-by: Keith Packard <keithp@keithp.com>