### PR TITLE
Support older picolibc (< 1.6)

### DIFF
--- a/chips/qemu/snek-qemu.c
+++ b/chips/qemu/snek-qemu.c
@@ -158,3 +158,24 @@ main(int argc, char **argv)
 	fflush(stdout);
 	exit(ret);
 }
+
+#ifdef _SNEK_NEED_STRFROMF
+int
+strfromf(char *__restrict str, size_t n,
+	 const char *__restrict format, float fp)
+{
+	return snprintf(str, n, format, __printf_float(fp));
+}
+#endif
+
+
+#ifdef _SNEK_NEED_STRTOF
+float
+strtof(const char *restrict nptr, char **restrict endptr)
+{
+	float f;
+	(void) sscanf(nptr, "%f", &f);
+	(void) endptr;
+	return f;
+}
+#endif

--- a/chips/qemu/snek-qemu.defs
+++ b/chips/qemu/snek-qemu.defs
@@ -36,7 +36,15 @@ PICOLIBC_CFLAGS= \
 
 OPT?=-Os
 
-CFLAGS=$(ARCH_CFLAGS) --oslib=semihost --crt0=semihost \
+# Add --crt0=semihost for picolibc >= 1.6
+CRT0_FLAG=$(shell \
+	(echo '#include "picolibc.h"'; \
+	echo '_PICOLIBC__ _PICOLIBC_MINOR__ __PICOLIBC_PATCHLEVEL__') | \
+	arm-none-eabi-gcc -E - --specs=picolibc.specs | \
+	grep '^[0-9]' | \
+	awk '{ if ($$1 > 1 || ($$1 == 1 && $$2 >= 6)) print "--crt0=semihost";}')
+
+CFLAGS=$(ARCH_CFLAGS) --oslib=semihost $(CRT0_FLAG) \
 	-std=c18 $(OPT) -g \
 	-I. -I$(SNEK_QEMU) -I$(SNEK_ROOT) $(PICOLIBC_CFLAGS) $(SNEK_CFLAGS)
 

--- a/chips/qemu/snek-qemu.h
+++ b/chips/qemu/snek-qemu.h
@@ -26,3 +26,15 @@
 extern int snek_qemu_getc(void);
 
 #define abort() exit(1)
+
+#if _PICOLIBC__ == 1 && (_PICOLIBC_MINOR__ < 6 || __PICOLIBC_PATCHLEVEL__ < 1)
+#define _SNEK_NEED_STRFROMF
+int
+strfromf(char *__restrict str, size_t n,
+	 const char *__restrict format, float fp);
+#endif
+
+#if _PICOLIBC__ == 1 && (_PICOLIBC_MINOR__ < 7 || __PICOLIBC_PATCHLEVEL__ < 5)
+#define _SNEK_NEED_STRTOF
+#endif
+

--- a/chips/samd21/ao-snek.h
+++ b/chips/samd21/ao-snek.h
@@ -111,4 +111,16 @@ ao_snek_apa102_write(void *gpio_d, uint8_t pin_d,
 		     int npixel,
 		     struct snek_neopixel *pixels);
 
+
+#if _PICOLIBC__ == 1 && (_PICOLIBC_MINOR__ < 6 || __PICOLIBC_PATCHLEVEL__ < 1)
+#define _SNEK_NEED_STRFROMF
+int
+strfromf(char *__restrict str, size_t n,
+	 const char *__restrict format, float fp);
+#endif
+
+#if _PICOLIBC__ == 1 && (_PICOLIBC_MINOR__ < 7 || __PICOLIBC_PATCHLEVEL__ < 5)
+#define _SNEK_NEED_STRTOF
+#endif
+
 #endif /* _AO_SNEK_H_ */

--- a/chips/samd21/ao-stdio.c
+++ b/chips/samd21/ao-stdio.c
@@ -36,3 +36,24 @@ STDIO_ALIAS(stderr);
 #else
 FILE *const __iob[3] = { &__stdio, &__stdio, &__stdio };
 #endif
+
+#ifdef _SNEK_NEED_STRFROMF
+int
+strfromf(char *__restrict str, size_t n,
+	 const char *__restrict format, float fp)
+{
+	return snprintf(str, n, format, __printf_float(fp));
+}
+#endif
+
+
+#ifdef _SNEK_NEED_STRTOF
+float
+strtof(const char *restrict nptr, char **restrict endptr)
+{
+	float f;
+	(void) sscanf(nptr, "%f", &f);
+	(void) endptr;
+	return f;
+}
+#endif


### PR DESCRIPTION
Older versions of picolibc didn't include strfromf, strtof or the --crt0 gcc command line option. Work around these by checking versions during the build and providing implementations of the str functions that work with snek.

Closes #65 

Signed-off-by: Keith Packard <keithp@keithp.com>