### PR TITLE
Share prngs across all devices

### DIFF
--- a/chips/atmega/snek-328p.c
+++ b/chips/atmega/snek-328p.c
@@ -481,19 +481,3 @@ snek_builtin_stopall(void)
 		}
 	return SNEK_NULL;
 }
-
-static uint32_t random_next;
-
-snek_poly_t
-snek_builtin_random_seed(snek_poly_t a)
-{
-	random_next = a.u;
-	return SNEK_NULL;
-}
-
-snek_poly_t
-snek_builtin_random_randrange(snek_poly_t a)
-{
-	random_next = random_next * 1103515245L + 12345L;
-	return snek_float_to_poly(random_next % (uint32_t) snek_poly_get_float(a));
-}

--- a/chips/atmega/snek-atmega.defs
+++ b/chips/atmega/snek-atmega.defs
@@ -33,6 +33,7 @@ SNEK_ATMEGA_SRC = \
 	snek-atmega-eeprom.c \
 	snek-io.c \
 	snek-atof.c \
+	snek-random-small.c \
 	snek-atmega-serial.c \
 	snek-atmega-time.c
 
@@ -51,6 +52,7 @@ SNEK_ATMEGA_MATH_BUILTINS = \
 SNEK_ATMEGA_BUILTINS = \
 	snek-eeprom.builtin \
 	snek-gpio.builtin \
+	snek-random.builtin \
 	snek-atmega.builtin
 
 SNEK_NO_FILE = 1

--- a/chips/avr/ao-snek-avr.c
+++ b/chips/avr/ao-snek-avr.c
@@ -486,22 +486,6 @@ snek_builtin_time_monotonic(void)
 	return snek_float_to_poly((float) snek_ticks() * SECONDS_PER_TICK);
 }
 
-static uint32_t random_next;
-
-snek_poly_t
-snek_builtin_random_seed(snek_poly_t a)
-{
-	random_next = a.u;
-	return SNEK_NULL;
-}
-
-snek_poly_t
-snek_builtin_random_randrange(snek_poly_t a)
-{
-	random_next = random_next * 1103515245L + 12345L;
-	return snek_float_to_poly(random_next % (uint32_t) snek_poly_get_float(a));
-}
-
 extern char __snek_data_start__, __snek_data_end__;
 extern char __snek_bss_start__, __snek_bss_end__;
 extern char __text_start__, __text_end__;

--- a/chips/avr/snek-avr.builtin
+++ b/chips/avr/snek-avr.builtin
@@ -14,5 +14,3 @@
 reset, 0
 time.sleep, 1
 time.monotonic, 0
-random.seed, 1
-random.randrange, 1

--- a/chips/avr/snek-avr.defs
+++ b/chips/avr/snek-avr.defs
@@ -21,6 +21,7 @@ SNEK_LOCAL_VPATH = $(SNEK_PORT):$(SNEK_AVR):$(SNEK_AO)
 SNEK_AVR_SRC = \
 	snek-io.c \
 	snek-pow.c \
+	snek-random-small.c \
 	snek-avr-eeprom.c \
 	ao-snek-avr.c \
 	ao-usb-avr.c \
@@ -43,6 +44,7 @@ SNEK_AVR_INC = \
 SNEK_AVR_BUILTINS = \
 	snek-gpio.builtin \
 	snek-eeprom.builtin \
+	snek-random.builtin \
 	snek-avr.builtin
 
 SNEK_NO_FILE = 1

--- a/chips/qemu/snek-qemu.builtin
+++ b/chips/qemu/snek-qemu.builtin
@@ -12,8 +12,6 @@
 # General Public License for more details.
 #
 exit, 1
-random.seed, 1
-random.randrange, 1
 time.monotonic, 0
 time.sleep, 1
 #include <snek-qemu.h>

--- a/chips/qemu/snek-qemu.c
+++ b/chips/qemu/snek-qemu.c
@@ -59,35 +59,6 @@ snek_builtin_exit(snek_poly_t a)
 	return a;
 }
 
-static uint64_t random_x, random_w;
-
-#define random_s 0xb5ad4eceda1ce2a9ULL
-
-snek_poly_t
-snek_builtin_random_seed(snek_poly_t a)
-{
-	random_x = a.u;
-	random_x |= random_x << 32;
-	random_w = 0;
-	return SNEK_NULL;
-}
-
-snek_poly_t
-snek_builtin_random_randrange(snek_poly_t a)
-{
-	uint32_t mod = snek_poly_get_float(a);
-
-	if (!mod) {
-		snek_error_value(a);
-		return SNEK_NULL;
-	}
-	random_x *= random_x;
-	random_w += random_s;
-	random_x += random_w;
-	random_x = (random_x >> 32) | (random_x << 32);
-	return snek_float_to_poly(random_x % mod);
-}
-
 static uint32_t
 centisecs(void)
 {

--- a/chips/qemu/snek-qemu.defs
+++ b/chips/qemu/snek-qemu.defs
@@ -14,6 +14,7 @@
 
 SNEK_LOCAL_SRC = \
 	snek-math.c \
+	snek-random.c \
 	snek-io.c \
 	snek-input.c \
 	snek-qemu.c
@@ -24,6 +25,7 @@ SNEK_LOCAL_INC = \
 SNEK_LOCAL_BUILTINS = \
 	snek-qemu.builtin \
 	snek-math.builtin \
+	snek-random.builtin \
 	snek-input.builtin
 
 SNEK_LOCAL_VPATH = $(SNEK_QEMU)

--- a/chips/samd21/snek-altos.builtin
+++ b/chips/samd21/snek-altos.builtin
@@ -15,7 +15,5 @@ time.sleep, 1
 time.monotonic, 0
 pulldown, 1
 reset, 0
-random.seed, 1
-random.randrange, 1
 neopixel, 1
 #include <ao-snek.h>

--- a/chips/samd21/snek-samd21.defs
+++ b/chips/samd21/snek-samd21.defs
@@ -21,6 +21,7 @@ SNEK_SAMD21_SRC = \
 	snek-altos.c \
 	snek-eeprom.c \
 	snek-math.c \
+	snek-random.c \
 	snek-gpio.c \
 	snek-io.c \
 	snek-input.c \
@@ -64,6 +65,7 @@ SNEK_SAMD21_BUILTINS = \
 	snek-eeprom.builtin \
 	snek-altos.builtin \
 	snek-math.builtin \
+	snek-random.builtin \
 	snek-input.builtin
 
 PICOLIBC_PRINTF_CFLAGS = -DPICOLIBC_FLOAT_PRINTF_SCANF

--- a/hosts/windows/Makefile
+++ b/hosts/windows/Makefile
@@ -17,10 +17,15 @@ SNEK_ROOT=../..
 SNEK_LOCAL_SRC = \
 	snek-windows.c \
 	snek-math.c \
+	snek-random.c \
 	snek-input.c
 
 SNEK_LOCAL_INC = snek-windows.h
-SNEK_LOCAL_BUILTINS = snek-windows.builtin $(SNEK_ROOT)/snek-math.builtin $(SNEK_ROOT)/snek-input.builtin
+SNEK_LOCAL_BUILTINS = \
+	snek-windows.builtin \
+	snek-math.builtin \
+	snek-random.builtin \
+	snek-input.builtin
 
 INF=altusmetrum.inf
 WINDOWS_FILES=snek.exe snek.ico snekde.py $(PDF) $(SNEK_ROOT)/examples $(SNEK_ROOT)/COPYING $(FIRMWARE) $(USBFIRMWARE) $(INF)

--- a/hosts/windows/snek-windows.builtin
+++ b/hosts/windows/snek-windows.builtin
@@ -14,7 +14,5 @@
 exit, 1
 time.sleep, 1
 time.monotonic, 0
-random.seed, 1
-random.randrange, 1
 #include "snek-windows.h"
 #define SNEK_POOL 262144

--- a/hosts/windows/snek-windows.c
+++ b/hosts/windows/snek-windows.c
@@ -138,17 +138,3 @@ snek_builtin_time_monotonic(void)
 {
 	return snek_float_to_poly(GetTickCount() / 1000.0f);
 }
-
-snek_poly_t
-snek_builtin_random_seed(snek_poly_t a)
-{
-	srand(a.u);
-	return SNEK_NULL;
-}
-
-snek_poly_t
-snek_builtin_random_randrange(snek_poly_t a)
-{
-	return snek_float_to_poly(rand() % (long int) snek_poly_get_float(a));
-}
-

--- a/ports/esp32/main/Makefile
+++ b/ports/esp32/main/Makefile
@@ -17,6 +17,7 @@ SNEK_ROOT=../../..
 SNEK_LOCAL_SRC = \
 	snek-main.c \
 	snek-math.c \
+	snek-random.c \
 	snek-input.c \
 	snek-esp32.c \
 	snek-io.c
@@ -26,8 +27,9 @@ SNEK_LOCAL_INC = \
 
 SNEK_LOCAL_BUILTINS = \
 	snek-esp32.builtin \
-	$(SNEK_ROOT)/snek-math.builtin \
-	$(SNEK_ROOT)/snek-input.builtin
+	snek-math.builtin \
+	snek-random.builtin \
+	snek-input.builtin
 
 include $(SNEK_ROOT)/snek.defs
 

--- a/ports/esp32/main/snek-esp32.builtin
+++ b/ports/esp32/main/snek-esp32.builtin
@@ -1,6 +1,4 @@
 reset, 0
 time.sleep, 1
 time.monotonic, 0
-random.seed, 1
-random.randrange, 1
 #include "snek-esp32.h"

--- a/ports/esp32/main/snek-esp32.c
+++ b/ports/esp32/main/snek-esp32.c
@@ -37,32 +37,3 @@ snek_builtin_time_monotonic(void)
 	TickType_t ticks = xTaskGetTickCount();
 	return snek_float_to_poly((float) ticks * (portTICK_PERIOD_MS / 1000.0f));
 }
-
-static uint64_t random_x, random_w;
-
-#define random_s 0xb5ad4eceda1ce2a9ULL
-
-snek_poly_t
-snek_builtin_random_seed(snek_poly_t a)
-{
-	random_x = a.u;
-	random_x |= random_x << 32;
-	random_w = 0;
-	return SNEK_NULL;
-}
-
-snek_poly_t
-snek_builtin_random_randrange(snek_poly_t a)
-{
-	uint32_t mod = snek_poly_get_float(a);
-
-	if (!mod) {
-		snek_error_value(a);
-		return SNEK_NULL;
-	}
-	random_x *= random_x;
-	random_w += random_s;
-	random_x += random_w;
-	random_x = (random_x >> 32) | (random_x << 32);
-	return snek_float_to_poly(random_x % mod);
-}

--- a/ports/ev3/Makefile
+++ b/ports/ev3/Makefile
@@ -25,6 +25,7 @@ SNEK_LOCAL_SRC = \
 	snek-main.c \
 	snek-posix.c \
 	snek-math.c \
+	snek-random.c \
 	snek-input.c \
 	snek-io.c \
 	sensors.c \
@@ -35,9 +36,10 @@ SNEK_LOCAL_INC = snek-ev3.h utils.h sensors.h motors.h
 SNEK_LOCAL_CFLAGS = -DSNEK_USE_GLIBC_2_4_MATH
 SNEK_LOCAL_BUILTINS = \
 	snek-ev3.builtin \
-	$(SNEK_ROOT)/snek-math.builtin \
-	$(SNEK_ROOT)/snek-eeprom.builtin \
-	$(SNEK_ROOT)/snek-input.builtin
+	snek-math.builtin \
+	snek-random.builtin \
+	snek-eeprom.builtin \
+	snek-input.builtin
 
 include $(SNEK_ROOT)/snek-install.defs
 

--- a/ports/ev3/snek-ev3.builtin
+++ b/ports/ev3/snek-ev3.builtin
@@ -14,8 +14,6 @@
 exit, 1
 time.sleep, 1
 time.monotonic, 0
-random.seed, 1
-random.randrange, 1
 
 # light sensor mode
 light_reflected, 1

--- a/ports/hifive1revb/Makefile
+++ b/ports/hifive1revb/Makefile
@@ -127,6 +127,7 @@ SNEK_LOCAL_SRC = \
 	watchdog.c \
 	snek-metal.c \
 	snek-math.c \
+	snek-random.c \
 	snek-io.c \
 	snek-input.c \
 	snek-metal-gpio.c \
@@ -138,6 +139,7 @@ SNEK_LOCAL_INC = \
 
 SNEK_LOCAL_BUILTINS = \
 	snek-math.builtin \
+	snek-random.builtin \
 	snek-gpio.builtin \
 	snek-input.builtin \
 	snek-hifive1revb.builtin

--- a/ports/hifive1revb/snek-hifive1revb.builtin
+++ b/ports/hifive1revb/snek-hifive1revb.builtin
@@ -40,6 +40,4 @@ SDA, -2, 20
 SCL, -2, 21
 time.sleep, 1
 time.monotonic, 0
-random.seed, 1
-random.randrange, 1
 reset, 0

--- a/ports/hifive1revb/snek-metal-builtin.c
+++ b/ports/hifive1revb/snek-metal-builtin.c
@@ -45,35 +45,6 @@ snek_builtin_time_monotonic(void)
 	return snek_float_to_poly(snek_millis() / 1000.0f);
 }
 
-static uint64_t random_x, random_w;
-
-#define random_s 0xb5ad4eceda1ce2a9ULL
-
-snek_poly_t
-snek_builtin_random_seed(snek_poly_t a)
-{
-	random_x = a.u;
-	random_x |= random_x << 32;
-	random_w = 0;
-	return SNEK_NULL;
-}
-
-snek_poly_t
-snek_builtin_random_randrange(snek_poly_t a)
-{
-	uint32_t mod = snek_poly_get_float(a);
-
-	if (!mod) {
-		snek_error_value(a);
-		return SNEK_NULL;
-	}
-	random_x *= random_x;
-	random_w += random_s;
-	random_x += random_w;
-	random_x = (random_x >> 32) | (random_x << 32);
-	return snek_float_to_poly(random_x % mod);
-}
-
 snek_poly_t
 snek_builtin_reset(void)
 {

--- a/ports/mega/Makefile
+++ b/ports/mega/Makefile
@@ -34,7 +34,6 @@ SNEK_LOCAL_INC = \
 SNEK_LOCAL_BUILTINS = \
 	$(SNEK_ATMEGA_BUILTINS) \
 	$(SNEK_ATMEGA_MATH_BUILTINS) \
-	snek-math.builtin \
 	snek-input.builtin \
 	snek-i2c.builtin \
 	snek-mega.builtin

--- a/ports/mega/snek-mega.c
+++ b/ports/mega/snek-mega.c
@@ -657,19 +657,3 @@ snek_builtin_stopall(void)
 		}
 	return SNEK_NULL;
 }
-
-static uint32_t random_next;
-
-snek_poly_t
-snek_builtin_random_seed(snek_poly_t a)
-{
-	random_next = a.u;
-	return SNEK_NULL;
-}
-
-snek_poly_t
-snek_builtin_random_randrange(snek_poly_t a)
-{
-	random_next = random_next * 1103515245L + 12345L;
-	return snek_float_to_poly(random_next % (uint32_t) snek_poly_get_float(a));
-}

--- a/ports/nano-every/snek-nano-every.c
+++ b/ports/nano-every/snek-nano-every.c
@@ -466,19 +466,3 @@ snek_builtin_stopall(void)
 		}
 	return SNEK_NULL;
 }
-
-static uint32_t random_next;
-
-snek_poly_t
-snek_builtin_random_seed(snek_poly_t a)
-{
-	random_next = a.u;
-	return SNEK_NULL;
-}
-
-snek_poly_t
-snek_builtin_random_randrange(snek_poly_t a)
-{
-	random_next = random_next * 1103515245L + 12345L;
-	return snek_float_to_poly(random_next % (uint32_t) snek_poly_get_float(a));
-}

--- a/ports/narrow-1284/snek-narrow-1284.c
+++ b/ports/narrow-1284/snek-narrow-1284.c
@@ -412,19 +412,3 @@ snek_builtin_stopall(void)
 		}
 	return SNEK_NULL;
 }
-
-static uint32_t random_next;
-
-snek_poly_t
-snek_builtin_random_seed(snek_poly_t a)
-{
-	random_next = a.u;
-	return SNEK_NULL;
-}
-
-snek_poly_t
-snek_builtin_random_randrange(snek_poly_t a)
-{
-	random_next = random_next * 1103515245L + 12345L;
-	return snek_float_to_poly(random_next % (uint32_t) snek_poly_get_float(a));
-}

--- a/ports/posix/Makefile
+++ b/ports/posix/Makefile
@@ -18,12 +18,17 @@ SNEK_LOCAL_SRC = \
 	snek-main.c \
 	snek-posix.c \
 	snek-math.c \
+	snek-random.c \
 	snek-curses.c \
 	snek-input.c
 
 SNEK_LOCAL_INC = snek-posix.h
 SNEK_LOCAL_CFLAGS = 
-SNEK_LOCAL_BUILTINS = snek-posix.builtin $(SNEK_ROOT)/snek-math.builtin $(SNEK_ROOT)/snek-input.builtin
+SNEK_LOCAL_BUILTINS = \
+	snek-posix.builtin \
+	snek-math.builtin \
+	snek-input.builtin \
+	snek-random.builtin
 
 include $(SNEK_ROOT)/snek-install.defs
 

--- a/ports/posix/snek-posix.builtin
+++ b/ports/posix/snek-posix.builtin
@@ -26,7 +26,5 @@ stdscr.addstr, 3
 stdscr.move, 2
 stdscr.refresh, 0
 stdscr.getch, 0
-random.seed, 1
-random.randrange, 1
 #include <snek-posix.h>
 #define SNEK_POOL 262144

--- a/ports/posix/snek-posix.c
+++ b/ports/posix/snek-posix.c
@@ -62,17 +62,3 @@ snek_builtin_time_monotonic(void)
 		start_sec = t.tv_sec;
 	return snek_float_to_poly((float) (t.tv_sec - start_sec) + (float) t.tv_nsec / 1e9f);
 }
-
-snek_poly_t
-snek_builtin_random_seed(snek_poly_t a)
-{
-	srandom(a.u);
-	return SNEK_NULL;
-}
-
-snek_poly_t
-snek_builtin_random_randrange(snek_poly_t a)
-{
-	return snek_float_to_poly(random() % (long int) snek_poly_get_float(a));
-}
-

--- a/snek-random-small.c
+++ b/snek-random-small.c
@@ -12,23 +12,33 @@
  * General Public License for more details.
  */
 
-#include <ao.h>
-#include <ao-snek.h>
-#include <snek.h>
+#include "snek.h"
+
+static uint32_t random_next;
 
 snek_poly_t
-snek_builtin_time_sleep(snek_poly_t a)
+snek_builtin_random_seed(snek_poly_t a)
 {
-	uint64_t	ticks = (snek_poly_get_float(a) * 1e9f + 0.5f);
-	uint64_t	expire = ao_time_ns() + ticks;
-
-	while (!snek_abort && (int64_t) (expire - ao_time_ns()) > 0)
-		;
+	random_next = a.u;
 	return SNEK_NULL;
 }
 
-snek_poly_t
-snek_builtin_time_monotonic(void)
+static void
+next_random(void)
 {
-	return snek_float_to_poly(ao_time_ns() / 1e9f);
+	random_next = random_next * 1103515245L + 12345L;
+}
+
+snek_poly_t
+snek_builtin_random_randrange(snek_poly_t a)
+{
+	next_random();
+	return snek_float_to_poly(random_next % (uint32_t) snek_poly_get_float(a));
+}
+
+snek_poly_t
+snek_builtin_random_random(void)
+{
+	next_random();
+	return snek_float_to_poly(random_next / 0x1p+31f);
 }

--- a/snek-random.builtin
+++ b/snek-random.builtin
@@ -11,6 +11,6 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
-time.sleep, 1
-time.monotonic, 0
-reset, 0
+random.seed, 1
+random.randrange, 1
+random.random, 0

--- a/snek-random.c
+++ b/snek-random.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2018 Keith Packard <keithp@keithp.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ */
+
+#include "snek.h"
+
+static uint64_t random_x, random_w;
+
+#define random_s 0xb5ad4eceda1ce2a9ULL
+
+snek_poly_t
+snek_builtin_random_seed(snek_poly_t a)
+{
+	random_x = a.u;
+	random_x |= random_x << 32;
+	random_w = 0;
+	return SNEK_NULL;
+}
+
+static void
+next_random(void)
+{
+	random_x *= random_x;
+	random_w += random_s;
+	random_x += random_w;
+	random_x = (random_x >> 32) | (random_x << 32);
+}
+
+snek_poly_t
+snek_builtin_random_randrange(snek_poly_t a)
+{
+	uint32_t mod = snek_poly_get_float(a);
+
+	if (!mod) {
+		snek_error_value(a);
+		return SNEK_NULL;
+	}
+	next_random();
+	return snek_float_to_poly(random_x % mod);
+}
+
+snek_poly_t
+snek_builtin_random_random(void)
+{
+	next_random();
+	return snek_float_to_poly(((uint32_t) random_x) / 0x1p+32);
+}


### PR DESCRIPTION
Create snek-random.c and snek-random-small.c, then share those across all snek implementations. Select snek-random-small.c for smaller devices to avoid needing 64-bit arithmetic.